### PR TITLE
Fixed optional geoprogress callback

### DIFF
--- a/geo.js
+++ b/geo.js
@@ -2,6 +2,10 @@ navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess,
     var lastCheckedPosition;
     var locationEventCount = 0;
     
+    if (geoprogress && geoprogress.constructor.name !== 'Function' && options === undefined){
+        options = geoprogress;
+        geoprogress = function(){};
+    };
     options = options || {};
 
     var checkLocation = function (position) {

--- a/geo.js
+++ b/geo.js
@@ -7,6 +7,7 @@ navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess,
         geoprogress = function(){};
     };
     options = options || {};
+    options.context = options.context || this;
 
     var checkLocation = function (position) {
         lastCheckedPosition = position;
@@ -18,7 +19,7 @@ navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess,
             navigator.geolocation.clearWatch(watchID);
             foundPosition(position);
         } else {
-            geoprogress(position);
+            geoprogress.call(options.context, position);
         }
     }
 
@@ -30,11 +31,11 @@ navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess,
     var onError = function (error) {
         clearTimeout(timerID);
         navigator.geolocation.clearWatch(watchID);
-        geolocationError(error);
+        geolocationError.call(options.context, error);
     }
 
     var foundPosition = function (position) {
-        geolocationSuccess(position);
+        geolocationSuccess.call(options.context, position);
     }
 
     if (!options.maxWait)            options.maxWait = 10000; // Default 10 seconds


### PR DESCRIPTION
Hi,

If we follow the readme sample the code would raise errors because the options is passed as third argument, when it actually should be the geoprogress callback. I've added a small check for those parameters in order to have them behave correctly in case of geoprogress not being informed but options do. (needs some testing tou)

Cheers,

Eric
