### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,17 @@ A better way to do this is to use <strong>navigator.geolocation.watchPosition()<
 
 The option parameters are identical to getCurrentPosition() with the following additions:
 <ul>
-   <li><strong>desiredAccuracy</strong>: The accuracy in meters that you consider "good enough". Once a location is found that meets this criterion, your callback will be called.</li>
-   <li><strong>maxWait</strong>: How long you are willing to wait (in milliseconds) for your desired accuracy. Once the function runs for maxWait milliseconds, it will stop trying and return the last location it was able to acquire. NOTE: If the desired accuracy is not achieved before the timeout, the onSuccess is still called. You will need to check the accuracy to confirm that you got what you expected. I did this because it's a "desired" accuracy, not a "required" accuracy. You can of course change this easily.</li>
-   <li><strong>countMin</strong>: First event may be cached (even on maximumAge=0). Default 2.
-   <li><strong>desiredAccuracyCountMin</strong>: You may wait for more (accurate) positions. Default 1.
-   <li><strong>enableLowAccuracyOnTimeout</strong>: You may to try to get at least a low accuracy result after maxWait (doubling worst case maxWait). Default false.
-  
+   <li><strong>desiredAccuracy</strong>=20): The accuracy in meters that you consider "good enough". Once a location is found that meets this criterion, your callback will be called. Default 20.</li>
+   <li><strong>maxWait</strong>=10000: How long you are willing to wait (in milliseconds) for your desired accuracy. Once the function runs for maxWait milliseconds, it will stop trying and return the best location it was able to acquire. NOTE: If the desired accuracy is not achieved before the timeout, the onSuccess is still called. You will need to check the accuracy to confirm that you got what you expected. I did this because it's a "desired" accuracy, not a "required" accuracy. You can of course change this easily.</li>
+   <li><strong>countMin</strong>=2: First event may be cached (even on maximumAge=0).
+   <li><strong>desiredAccuracyCountMin</strong>=1: You may wait for more (accurate) positions.
+   <li><strong>enableLowAccuracyOnTimeout</strong>=false: You may try to get at least a low accuracy result after maxWait (doubling worst case maxWait).  
 </ul>
 The following params also exist for getCurrentPosition() but are set for you in getAccurateCurrentPosition():
 <ul>
-   <li><strong>timeout</strong>: If no timeout is specified, it will be set to the maxWait value</li>
-   <li><strong>enableHighAccuracy</strong>: This is forced to true (otherwise, why are you using this function?!)</li>
-   <li><strong>maximumAge</strong>: This is forced to zero since we only want current location information</li>
+   <li><strong>timeout</strong>=maxWait: If no timeout is specified, it will be set to the maxWait value.</li>
+   <li><strong>enableHighAccuracy</strong>=true: This is forced to true (otherwise, why are you using this function?!)</li>
+   <li><strong>maximumAge</strong>=0: You may allow a cached position (as a starter).</li>
 </ul>
 
 <h3>Sample usage:</h3>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The option parameters are identical to getCurrentPosition() with the following a
    <li><strong>desiredAccuracy=20</strong>: The accuracy in meters that you consider "good enough". Once a location is found that meets this criterion, your callback will be called.</li>
    <li><strong>maxWait=10000</strong>: How long you are willing to wait (in milliseconds) for your desired accuracy. Once the function runs for maxWait milliseconds, it will stop trying and return the best location it was able to acquire. NOTE: If the desired accuracy is not achieved before the timeout, the onSuccess is still called. You will need to check the accuracy to confirm that you got what you expected. I did this because it's a "desired" accuracy, not a "required" accuracy. You can of course change this easily.</li>
    <li><strong>countMin=2</strong>: First event may be cached (even on maximumAge=0).
-   <li><strong>desiredAccuracyCountMin=1</strong>: You may wait for more (accurate) positions.
+   <li><strong>desiredAccuracyCountMin=1</strong>: You may wait and allow for more (accurate) positions. MaxWait is unaffected by this.
    <li><strong>enableLowAccuracyOnTimeout=false</strong>: You may try to get at least a low accuracy result after maxWait (doubling worst case maxWait).  
 </ul>
 The following params also exist for getCurrentPosition() but are set for you in getAccurateCurrentPosition():
@@ -27,6 +27,11 @@ The following params also exist for getCurrentPosition() but are set for you in 
 <code>navigator.geolocation.getAccurateCurrentPosition(onSuccess, onError, onProgress, 
                                                         {desiredAccuracy:20, maxWait:15000});</code>
 
-Translating the above options into english -- This will attempt to find the device location with an accuracy of at least 20 meters and attempt to achieve this accuracy for 15 seconds
+Translating the above options into english -- This will attempt for 15 seconds to find the device location and will return as soon the accuracy is at least 20 meters. Otherwise the best result found is returned.
+
+
+<h3>Recommendation:</h3>
+You should call this function inititally with <code>{maxWait:120000}</code> in the background, so a fix can be aquired.
+Thus, subsequent calls are much quicker. For example <code>{desiredAccuracy:20, desiredAccuracyCountMin:5, maxWait:20000, enableLowAccuracyOnTimeout:true}</code> to allow for the best location out of 5 with an accuracy of at least 20m, if this is possible in the 20s given. If there is no gps position, it will return the best it has.
 
 Blogged at <a target="_blank" href="http://gregsramblings.com/2012/06/30/improving-geolocation-getcurrentposition-with-getaccuratecurrentposition/">http://gregsramblings.com/2012/06/30/improving-geolocation-getcurrentposition-with-getaccuratecurrentposition/</a>

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ The following params also exist for getCurrentPosition() but are set for you in 
 
 <h3>Callbacks:</h3>
 <ul>
-   <li><strong>onProgress(Position)</strong>: Standard geolocation <a href="https://developer.mozilla.org/en-US/docs/Web/API/Position">position</a>
-   <li><strong>onError(PositionError)</strong>: Standard geolocation  <a href="https://developer.mozilla.org/en-US/docs/Web/API/PositionError">Positionerror</a>
+   <li><strong>onProgress(Position)</strong>: Standard geolocation <a href="https://developer.mozilla.org/en-US/docs/Web/API/Position">Position</a>
+   <li><strong>onError(PositionError)</strong>: Standard geolocation  <a href="https://developer.mozilla.org/en-US/docs/Web/API/PositionError">PositionError</a>
    <li><strong>onSuccess(Position, resultString)</strong>: resultString is 'success' if desired accuracy is met or 'timeout'
 </ul>
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ In my own testing with an iPhone 4s and an HTC Inspire, when I would check getCu
 
 A better way to do this is to use <strong>navigator.geolocation.watchPosition()</strong>. This method will do a callback every time the location changes or every time the device improves the accuracy (based on my observations). In my own testing with a freshly booted device, it will take between 2 and 6 callbacks to get to something highly accurate.  This led me to write this very simple JavaScript function that uses watchPosition() in combination with a simple timer.
 
+<h3>Options:</h3>
 The option parameters are identical to getCurrentPosition() with the following additions:
 <ul>
    <li><strong>desiredAccuracy=20</strong>: The accuracy in meters that you consider "good enough". Once a location is found that meets this criterion, your callback will be called.</li>
@@ -22,6 +23,14 @@ The following params also exist for getCurrentPosition() but are set for you in 
    <li><strong>enableHighAccuracy=true</strong>: This is forced to true (otherwise, why are you using this function?!)</li>
    <li><strong>maximumAge=0</strong>: You may allow a cached position (as a starter).</li>
 </ul>
+
+<h3>Callbacks:</h3>
+<ul>
+   <li><strong>onProgress(Position)</strong>: Standard geolocation <a href="https://developer.mozilla.org/en-US/docs/Web/API/Position">position</a>
+   <li><strong>onError(PositionError)</strong>: Standard geolocation  <a href="https://developer.mozilla.org/en-US/docs/Web/API/PositionError">Positionerror</a>
+   <li><strong>onSuccess(Position, resultString)</strong>: resultString is 'success' if desired accuracy is met or 'timeout'
+</ul>
+
 
 <h3>Sample usage:</h3>
 <code>navigator.geolocation.getAccurateCurrentPosition(onSuccess, onError, onProgress, 

--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ A better way to do this is to use <strong>navigator.geolocation.watchPosition()<
 
 The option parameters are identical to getCurrentPosition() with the following additions:
 <ul>
-   <li><strong>desiredAccuracy</strong>=20): The accuracy in meters that you consider "good enough". Once a location is found that meets this criterion, your callback will be called. Default 20.</li>
-   <li><strong>maxWait</strong>=10000: How long you are willing to wait (in milliseconds) for your desired accuracy. Once the function runs for maxWait milliseconds, it will stop trying and return the best location it was able to acquire. NOTE: If the desired accuracy is not achieved before the timeout, the onSuccess is still called. You will need to check the accuracy to confirm that you got what you expected. I did this because it's a "desired" accuracy, not a "required" accuracy. You can of course change this easily.</li>
-   <li><strong>countMin</strong>=2: First event may be cached (even on maximumAge=0).
-   <li><strong>desiredAccuracyCountMin</strong>=1: You may wait for more (accurate) positions.
-   <li><strong>enableLowAccuracyOnTimeout</strong>=false: You may try to get at least a low accuracy result after maxWait (doubling worst case maxWait).  
+   <li><strong>desiredAccuracy=20</strong>: The accuracy in meters that you consider "good enough". Once a location is found that meets this criterion, your callback will be called.</li>
+   <li><strong>maxWait=10000</strong>: How long you are willing to wait (in milliseconds) for your desired accuracy. Once the function runs for maxWait milliseconds, it will stop trying and return the best location it was able to acquire. NOTE: If the desired accuracy is not achieved before the timeout, the onSuccess is still called. You will need to check the accuracy to confirm that you got what you expected. I did this because it's a "desired" accuracy, not a "required" accuracy. You can of course change this easily.</li>
+   <li><strong>countMin=2</strong>: First event may be cached (even on maximumAge=0).
+   <li><strong>desiredAccuracyCountMin=1</strong>: You may wait for more (accurate) positions.
+   <li><strong>enableLowAccuracyOnTimeout=false</strong>: You may try to get at least a low accuracy result after maxWait (doubling worst case maxWait).  
 </ul>
 The following params also exist for getCurrentPosition() but are set for you in getAccurateCurrentPosition():
 <ul>
-   <li><strong>timeout</strong>=maxWait: If no timeout is specified, it will be set to the maxWait value.</li>
-   <li><strong>enableHighAccuracy</strong>=true: This is forced to true (otherwise, why are you using this function?!)</li>
-   <li><strong>maximumAge</strong>=0: You may allow a cached position (as a starter).</li>
+   <li><strong>timeout</strong>: Is set to maxWait value. It is not recommended to change this value.</li>
+   <li><strong>enableHighAccuracy=true</strong>: This is forced to true (otherwise, why are you using this function?!)</li>
+   <li><strong>maximumAge=0</strong>: You may allow a cached position (as a starter).</li>
 </ul>
 
 <h3>Sample usage:</h3>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ The option parameters are identical to getCurrentPosition() with the following a
 <ul>
    <li><strong>desiredAccuracy</strong>: The accuracy in meters that you consider "good enough". Once a location is found that meets this criterion, your callback will be called.</li>
    <li><strong>maxWait</strong>: How long you are willing to wait (in milliseconds) for your desired accuracy. Once the function runs for maxWait milliseconds, it will stop trying and return the last location it was able to acquire. NOTE: If the desired accuracy is not achieved before the timeout, the onSuccess is still called. You will need to check the accuracy to confirm that you got what you expected. I did this because it's a "desired" accuracy, not a "required" accuracy. You can of course change this easily.</li>
+   <li><strong>countMin</strong>: First event may be cached (even on maximumAge=0). Default 2.
+   <li><strong>desiredAccuracyCountMin</strong>: You may wait for more (accurate) positions. Default 1.
+   <li><strong>enableLowAccuracyOnTimeout</strong>: You may to try to get at least a low accuracy result after maxWait (doubling worst case maxWait). Default false.
+  
 </ul>
 The following params also exist for getCurrentPosition() but are set for you in getAccurateCurrentPosition():
 <ul>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The option parameters are identical to getCurrentPosition() with the following a
    <li><strong>maxWait=10000</strong>: How long you are willing to wait (in milliseconds) for your desired accuracy. Once the function runs for maxWait milliseconds, it will stop trying and return the best location it was able to acquire. NOTE: If the desired accuracy is not achieved before the timeout, the onSuccess is still called. You will need to check the accuracy to confirm that you got what you expected. I did this because it's a "desired" accuracy, not a "required" accuracy. You can of course change this easily.</li>
    <li><strong>countMin=2</strong>: First event may be cached (even on maximumAge=0).
    <li><strong>desiredAccuracyCountMin=1</strong>: You may wait and allow for more (accurate) positions. MaxWait is unaffected by this.
-   <li><strong>enableLowAccuracyOnTimeout=false</strong>: You may try to get at least a low accuracy result after maxWait (doubling worst case maxWait).  
+   <li><strong>enableLowAccuracy=false</strong>: Simultaneously a low accuracy result is searched (seems to be ignored on Chrome 43).  
 </ul>
 The following params also exist for getCurrentPosition() but are set for you in getAccurateCurrentPosition():
 <ul>

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "getAccurateCurrentPosition",
+  "version": "0.1.0",
+  "homepage": "https://github.com/zevero/getAccurateCurrentPosition",
+  "authors": [
+    "gwilsen and zevero"
+  ],
+  "description": "Simple function to complement navigator.geolocation - fine tuning the location before replying",
+  "main": "geo.js",
+  "moduleType": [],
+  "keywords": [
+    "geolocation",
+    "enableHighAccuracy",
+    "location",
+    "gps",
+    "html5",
+    "navigator"
+  ],
+  "license": "MIT"
+}

--- a/geo.js
+++ b/geo.js
@@ -35,11 +35,11 @@ navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess,
         geolocationSuccess(position);
     };
 
-    if (!options.maxWait)            options.maxWait = 10000; // Default 10 seconds
-    if (!options.desiredAccuracy)    options.desiredAccuracy = 20; // Default 20 meters
-    if (!options.timeout)            options.timeout = options.maxWait; // Default to maxWait
-    if (!options.maximumAge)         options.maximumAge = 0; // Default current locations only
-    if (!options.countMin)           options.countMin = 1; // Default ignore first event because some devices send a cached
+    if (isNaN(options.maxWait))          options.maxWait = 10000; // Default 10 seconds
+    if (isNaN(options.desiredAccuracy))  options.desiredAccuracy = 20; // Default 20 meters
+    if (isNaN(options.timeout))          options.timeout = options.maxWait; // Default to maxWait
+    if (isNaN(options.maximumAge))       options.maximumAge = 0; // Default current locations only
+    if (isNaN(options.countMin))         options.countMin = 1; // Default ignore first event because some devices send a cached
                                                            // location even when maxaimumAge is set to zero
     
     options.enableHighAccuracy = true; // Force high accuracy (otherwise, why are you using this function?)

--- a/geo.js
+++ b/geo.js
@@ -1,8 +1,20 @@
+/*navigator.geolocation.test = 100;
+var global_geo_int = setInterval(function(){
+  if (!navigator.geolocation || !navigator.geolocation.test){
+    clearInterval(global_geo_int);
+    return console.log('geo_stopped');
+  }
+  console.log(navigator.geolocation.test--);
+},10);
+console.log(navigator.geolocation.test);
+*/
+setTimeout(function(){  //navigator.geolocation is OVERWRITTEN on startup. So we load and use it with timeout
+console.log('extending navigator.geolocation with getAccurateCurrentPosition');
 navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess, geolocationError, geoprogress, options) {
     var bestCheckedPosition,
         locationEventCount = 0,
         desiredAccuracyCount = 0,
-        watchID,
+        watchID,watchID_low,
         timerID;
 
     options = options || {};
@@ -19,14 +31,15 @@ navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess,
             (locationEventCount >= options.countMin)) {
             clearTimeout(timerID);
             navigator.geolocation.clearWatch(watchID);
-            geolocationSuccess(bestCheckedPosition);
+            geolocationSuccess(bestCheckedPosition, 'success');
         }
     };
 
     var stopTrying = function () {
         navigator.geolocation.clearWatch(watchID);
-        if (bestCheckedPosition) geolocationSuccess(bestCheckedPosition);
-        else geolocationError({code:3, message:'Timeout after trying for waitMax ms!'}); //sniff
+        navigator.geolocation.clearWatch(watchID_low);
+        if (bestCheckedPosition) geolocationSuccess(bestCheckedPosition, 'timeout');
+        else geolocationError({code:3, message:'Timeout after trying for '+options.maxWait+' ms!'}); //sniff
     };
 
     var onError = function (error) {
@@ -45,7 +58,7 @@ navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess,
     if (isNaN(options.countMin))     options.countMin = 2; // Default ignore first event because some devices send a cached
                                                            // location even when maxaimumAge is set to zero    
                                                            
-    if (options.enableLowAccuracy) navigator.geolocation.getCurrentPosition(checkLocation, function(){}, options);
+    if (options.enableLowAccuracy) watchID_low = navigator.geolocation.getCurrentPosition(checkLocation, function(e){console.log('getAccuratePostition LowAccuracy Error',e.code);}, options);
        //Optionally start a low Accuracy reading. I expected to find an early result as fallback, if no better results are found
        //however this the enableHighAccuracy flag seems to be bluntly ignored on Chrome 43 and others
        // see http://stackoverflow.com/questions/17804469/html5-geolocation-ignores-enablehighaccuracy-option/32521789
@@ -54,3 +67,4 @@ navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess,
     watchID = navigator.geolocation.watchPosition(checkLocation, onError, options);
     timerID = setTimeout(stopTrying, options.maxWait); // Set a timeout that will abandon the location loop
 };
+},200); //it is overwritten around 10-20ms after load. So 200 ms should be enough?

--- a/geo.js
+++ b/geo.js
@@ -15,8 +15,8 @@ navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess,
         locationEventCount = locationEventCount + 1;
 
         if ((position.coords.accuracy <= options.desiredAccuracy) && 
-            (++desiredAccuracyCount>= options.desiredAccuracyCountMin) &&
-            (locationEventCount > options.countMin)) {
+            (++desiredAccuracyCount >= options.desiredAccuracyCountMin) &&
+            (locationEventCount >= options.countMin)) {
             clearTimeout(timerID);
             navigator.geolocation.clearWatch(watchID);
             geolocationSuccess(bestCheckedPosition);
@@ -41,13 +41,13 @@ navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess,
       navigator.geolocation.getCurrentPosition(geolocationSuccess, geolocationError, options);
     };
             
-    if (isNaN(options.maxWait))          options.maxWait = 10000; // Default 10 seconds
-    if (isNaN(options.desiredAccuracy))  options.desiredAccuracy = 20; // Default 20 meters
-    if (isNaN(options.desiredAccuracyCountMin))  options.desiredAccuracyCountMin = 1; // Default get first position of desiredAccuracy
+    if (isNaN(options.maxWait))                 options.maxWait = 10000; // Default 10 seconds
+    if (isNaN(options.desiredAccuracy))         options.desiredAccuracy = 20; // Default 20 meters
+    if (isNaN(options.desiredAccuracyCountMin)) options.desiredAccuracyCountMin = 1; // Default get first position of desiredAccuracy
     
-    if (isNaN(options.timeout))          options.timeout = options.maxWait; // Default to maxWait
-    if (isNaN(options.maximumAge))       options.maximumAge = 0; // Default current locations only
-    if (isNaN(options.countMin))         options.countMin = 1; // Default ignore first event because some devices send a cached
+    if (isNaN(options.timeout))      options.timeout = options.maxWait; // Default to maxWait
+    if (isNaN(options.maximumAge))   options.maximumAge = 0; // Default current locations only
+    if (isNaN(options.countMin))     options.countMin = 2; // Default ignore first event because some devices send a cached
                                                            // location even when maxaimumAge is set to zero
     
     options.enableHighAccuracy = true; // Force high accuracy (otherwise, why are you using this function?)

--- a/geo.js
+++ b/geo.js
@@ -39,8 +39,8 @@ navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess,
     if (!options.maxWait)            options.maxWait = 10000; // Default 10 seconds
     if (!options.desiredAccuracy)    options.desiredAccuracy = 20; // Default 20 meters
     if (!options.timeout)            options.timeout = options.maxWait; // Default to maxWait
-
-    options.maximumAge = 0; // Force current locations only
+    if (!options.maximumAge)         options.maximumAge = 0; // Default current locations only
+    
     options.enableHighAccuracy = true; // Force high accuracy (otherwise, why are you using this function?)
 
     watchID = navigator.geolocation.watchPosition(checkLocation, onError, options);

--- a/geo.js
+++ b/geo.js
@@ -1,5 +1,5 @@
 navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess, geolocationError, geoprogress, options) {
-    var lastCheckedPosition,
+    var bestCheckedPosition,
         locationEventCount = 0,
         watchID,
         timerID;
@@ -7,7 +7,10 @@ navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess,
     options = options || {};
 
     var checkLocation = function (position) {
-        lastCheckedPosition = position;
+        geoprogress(position);
+        if (!bestCheckedPosition || position.coords.accuracy <= bestCheckedPosition.coords.accuracy) {
+          bestCheckedPosition = position;
+        }
         locationEventCount = locationEventCount + 1;
         // We ignore the first event unless it's the only one received because some devices seem to send a cached
         // location even when maxaimumAge is set to zero
@@ -15,14 +18,12 @@ navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess,
             clearTimeout(timerID);
             navigator.geolocation.clearWatch(watchID);
             foundPosition(position);
-        } else {
-            geoprogress(position);
         }
     };
 
     var stopTrying = function () {
         navigator.geolocation.clearWatch(watchID);
-        foundPosition(lastCheckedPosition);
+        foundPosition(bestCheckedPosition);
     };
 
     var onError = function (error) {

--- a/geo.js
+++ b/geo.js
@@ -1,6 +1,7 @@
 navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess, geolocationError, geoprogress, options) {
     var bestCheckedPosition,
         locationEventCount = 0,
+        desiredAccuracyCount = 0,
         watchID,
         timerID;
 
@@ -13,10 +14,12 @@ navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess,
         }
         locationEventCount = locationEventCount + 1;
 
-        if ((position.coords.accuracy <= options.desiredAccuracy) && (locationEventCount > options.countMin)) {
+        if ((position.coords.accuracy <= options.desiredAccuracy) && 
+            (++desiredAccuracyCount>= options.desiredAccuracyCountMin) &&
+            (locationEventCount > options.countMin)) {
             clearTimeout(timerID);
             navigator.geolocation.clearWatch(watchID);
-            geolocationSuccess(position);
+            geolocationSuccess(bestCheckedPosition);
         }
     };
 
@@ -40,6 +43,8 @@ navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess,
             
     if (isNaN(options.maxWait))          options.maxWait = 10000; // Default 10 seconds
     if (isNaN(options.desiredAccuracy))  options.desiredAccuracy = 20; // Default 20 meters
+    if (isNaN(options.desiredAccuracyCountMin))  options.desiredAccuracyCountMin = 1; // Default get first position of desiredAccuracy
+    
     if (isNaN(options.timeout))          options.timeout = options.maxWait; // Default to maxWait
     if (isNaN(options.maximumAge))       options.maximumAge = 0; // Default current locations only
     if (isNaN(options.countMin))         options.countMin = 1; // Default ignore first event because some devices send a cached

--- a/geo.js
+++ b/geo.js
@@ -12,9 +12,8 @@ navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess,
           bestCheckedPosition = position;
         }
         locationEventCount = locationEventCount + 1;
-        // We ignore the first event unless it's the only one received because some devices seem to send a cached
-        // location even when maxaimumAge is set to zero
-        if ((position.coords.accuracy <= options.desiredAccuracy) && (locationEventCount > 1)) {
+
+        if ((position.coords.accuracy <= options.desiredAccuracy) && (locationEventCount > options.countMin)) {
             clearTimeout(timerID);
             navigator.geolocation.clearWatch(watchID);
             foundPosition(position);
@@ -40,6 +39,8 @@ navigator.geolocation.getAccurateCurrentPosition = function (geolocationSuccess,
     if (!options.desiredAccuracy)    options.desiredAccuracy = 20; // Default 20 meters
     if (!options.timeout)            options.timeout = options.maxWait; // Default to maxWait
     if (!options.maximumAge)         options.maximumAge = 0; // Default current locations only
+    if (!options.countMin)           options.countMin = 1; // Default ignore first event because some devices send a cached
+                                                           // location even when maxaimumAge is set to zero
     
     options.enableHighAccuracy = true; // Force high accuracy (otherwise, why are you using this function?)
 


### PR DESCRIPTION
Thank you for your nice library. I was implementing roughly the same ideas, but it is much cleaner doing it by extending navigator.geolocation than polluting my proper code...

I wanted to make some improvements however:
1. Use bestCheckedPostion instead of lastCheckedPosition,
2. Always call geoprogress (also the last one)
3. Dont force maximumAge. Can be set optionally
4. New Option countMin, which is defaulted to 2 (exactly as it was)
5. Check Options with isNaN() to allow for 0 (would be overwritten otherwise)
6. New Option enableLowAccuracyOnTimeout (calls getCurrentPosition with lowAccuracy doubling timeout)
7.  New Option desiredAccuracyCountMin, so we can wait just a little bit longer for an even better result (maxWait is unaffected)

Everything is backwards compatible but
- not lastCheckedPosition but bestCheckedPosition is returned
- geoprogress is called one more time (along with the result)
