### PR TITLE
Add GPS demo + landing page for GitHub Pages hosting

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>getAccurateCurrentPosition demo</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body { font: 16px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 600px; margin: 1em auto; padding: 1em; line-height: 1.4; }
+  h1 { margin: 0 0 0.3em; font-size: 1.4em; }
+  .lead { color: #666; margin-top: 0; }
+  .row { display: flex; gap: 1em; margin: 0.5em 0; }
+  .row label { flex: 1; font-size: 0.9em; color: #444; }
+  input[type=number] { font: inherit; padding: 0.5em; width: 100%; margin-top: 0.25em; }
+  button { font: 16px -apple-system, BlinkMacSystemFont, sans-serif; padding: 0.85em 1.5em; margin-top: 1em; background: #2a6df4; color: white; border: 0; border-radius: 8px; -webkit-appearance: none; cursor: pointer; width: 100%; font-weight: 600; }
+  button:disabled { opacity: 0.5; }
+  .result, .progress { padding: 0.75em; margin: 0.5em 0; border-radius: 6px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; white-space: pre-wrap; word-break: break-word; }
+  .result.success { background: #eafaf1; border-left: 4px solid #2ecc71; color: #145a32; }
+  .result.error { background: #fdecea; border-left: 4px solid #e74c3c; color: #922b21; }
+  .progress { background: #fef5e7; border-left: 4px solid #f39c12; color: #7d5108; }
+  .map-link { display: inline-block; margin-top: 0.5em; padding: 0.5em 0.75em; background: #2a6df4; color: white; text-decoration: none; border-radius: 6px; }
+  small { color: #888; display: block; margin-top: 1.5em; font-size: 12px; line-height: 1.5; }
+  a { color: #2a6df4; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #1c1c1e; color: #ddd; }
+    .lead { color: #aaa; }
+    .row label { color: #ccc; }
+    input { background: #2c2c2e; color: white; border: 1px solid #444; }
+    .result.success { background: #14322a; color: #a3e6c1; }
+    .result.error { background: #3a1a18; color: #f5b7b1; }
+    .progress { background: #3a2e17; color: #f7ca84; }
+    small { color: #888; }
+  }
+</style>
+</head>
+<body>
+<h1>getAccurateCurrentPosition</h1>
+<p class="lead">Real GPS demo. Tap the button and grant location access when prompted.</p>
+
+<div class="row">
+  <label>desiredAccuracy (meters)
+    <input id="accuracy" type="number" value="20" min="1">
+  </label>
+  <label>maxWait (seconds)
+    <input id="maxwait" type="number" value="15" min="1">
+  </label>
+</div>
+
+<button id="go">Get accurate position</button>
+
+<div id="status"></div>
+<div id="updates"></div>
+
+<small>
+  Each callback below is a single <code>watchPosition</code> update.
+  The library returns the first one whose accuracy meets your threshold (after ignoring a possibly-cached first reading),
+  or the last one it saw when <code>maxWait</code> elapses.
+  <br><br>
+  <a href="test.html">Run automated tests</a> &middot;
+  <a href="https://github.com/gregsramblings/getAccurateCurrentPosition" target="_blank" rel="noopener">View source on GitHub</a>
+</small>
+
+<script src="geo.js"></script>
+<script>
+  const btn = document.getElementById('go');
+  const status = document.getElementById('status');
+  const updates = document.getElementById('updates');
+
+  function setStatus(html) { status.innerHTML = html; }
+  function logProgress(text) {
+    const el = document.createElement('div');
+    el.className = 'progress';
+    el.textContent = text;
+    updates.appendChild(el);
+  }
+
+  btn.addEventListener('click', function () {
+    btn.disabled = true;
+    setStatus('');
+    updates.innerHTML = '';
+
+    if (!navigator.geolocation || !navigator.geolocation.getAccurateCurrentPosition) {
+      setStatus('<div class="result error">getAccurateCurrentPosition not available. Check that geo.js loaded.</div>');
+      btn.disabled = false;
+      return;
+    }
+
+    const desiredAccuracy = parseFloat(document.getElementById('accuracy').value);
+    const maxWait = parseFloat(document.getElementById('maxwait').value) * 1000;
+    const t0 = Date.now();
+
+    navigator.geolocation.getAccurateCurrentPosition(
+      function onSuccess(pos) {
+        const dt = ((Date.now() - t0) / 1000).toFixed(1);
+        const lat = pos.coords.latitude;
+        const lng = pos.coords.longitude;
+        const acc = pos.coords.accuracy;
+        const met = acc <= desiredAccuracy ? 'met threshold' : 'best available at timeout';
+        const mapURL = 'https://www.google.com/maps?q=' + lat + ',' + lng;
+        setStatus(
+          '<div class="result success">SUCCESS after ' + dt + 's (' + met + ')\n' +
+          'lat:      ' + lat + '\n' +
+          'lng:      ' + lng + '\n' +
+          'accuracy: ' + acc + ' m</div>' +
+          '<a class="map-link" href="' + mapURL + '" target="_blank" rel="noopener">View on Google Maps</a>'
+        );
+        btn.disabled = false;
+      },
+      function onError(err) {
+        const codes = { 1: 'PERMISSION_DENIED', 2: 'POSITION_UNAVAILABLE', 3: 'TIMEOUT' };
+        const name = codes[err.code] || ('CODE ' + err.code);
+        setStatus('<div class="result error">ERROR: ' + name + '\n' + (err.message || '') + '</div>');
+        btn.disabled = false;
+      },
+      function onProgress(pos) {
+        const dt = ((Date.now() - t0) / 1000).toFixed(1);
+        logProgress('+' + dt + 's   accuracy: ' + pos.coords.accuracy + ' m');
+      },
+      { desiredAccuracy: desiredAccuracy, maxWait: maxWait }
+    );
+  });
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>getAccurateCurrentPosition</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 16px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 600px; margin: 2em auto; padding: 1em; line-height: 1.5; }
+  h1 { margin: 0 0 0.3em; }
+  p.lead { color: #666; margin-top: 0; }
+  ul { padding-left: 0; list-style: none; }
+  li { margin: 0.75em 0; }
+  a.card { display: block; padding: 1em; background: #f4f6fb; border-radius: 8px; text-decoration: none; color: inherit; border-left: 4px solid #2a6df4; }
+  a.card strong { display: block; color: #2a6df4; font-size: 1.05em; }
+  a.card span { display: block; color: #555; font-size: 0.9em; margin-top: 0.2em; }
+  small { color: #888; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #1c1c1e; color: #ddd; }
+    p.lead, small { color: #aaa; }
+    a.card { background: #2c2c2e; }
+    a.card span { color: #bbb; }
+  }
+</style>
+</head>
+<body>
+<h1>getAccurateCurrentPosition</h1>
+<p class="lead">A small enhancement to <code>navigator.geolocation</code> that waits for GPS to refine its reading before returning.</p>
+<ul>
+  <li><a class="card" href="demo.html"><strong>Live GPS demo &rarr;</strong><span>Exercises the library against your device's real location.</span></a></li>
+  <li><a class="card" href="test.html"><strong>Automated test page &rarr;</strong><span>10 mocked scenarios verifying the library logic.</span></a></li>
+</ul>
+<small>Source: <a href="https://github.com/gregsramblings/getAccurateCurrentPosition">github.com/gregsramblings/getAccurateCurrentPosition</a></small>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds two static pages so the library can be hosted on GitHub Pages and tested from a phone:

- **`demo.html`** — live GPS demo. Tap a button, grant location access, watch progress updates roll in, see the final lat/lng/accuracy and a Google Maps link. Mobile-friendly layout with dark mode.
- **`index.html`** — tiny landing page that links to the demo and the existing automated test page.

Once merged, enable GitHub Pages (Settings → Pages → Source: `Deploy from a branch` → `master` / `/ (root)`) and the pages will be live at:

- `https://gregsramblings.github.io/getAccurateCurrentPosition/`
- `https://gregsramblings.github.io/getAccurateCurrentPosition/demo.html`
- `https://gregsramblings.github.io/getAccurateCurrentPosition/test.html`

GitHub Pages serves over HTTPS, which is required by iOS Safari for geolocation prompts.

## Test plan

- [x] Demo page mocked end-to-end (Playwright) — success path renders correctly with no JS errors.
- [ ] Once Pages is enabled, open the demo URL on iPhone Safari, grant location, confirm progress updates appear and a final accurate fix is returned.
- [ ] Open the test URL on iPhone Safari — confirm 10/10 pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_015h2QiNrcp8ki2THR6922Ah)_