### PR TITLE
Rewrite README in Markdown with accurate API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,90 @@
-getAccurateCurrentPosition
-==========================
-<a href="https://github.com/gwilson/getAccurateCurrentPosition" target="_blank"><strong>getAccurateCurrentPosition()</strong></a> is a simple enhancement to <a href="http://dev.w3.org/geo/api/spec-source.html" target="_blank">navigator.geolocation</a> that provides a more accurate and predictable result.  It is intended for any geolocation-enabled web browser. This is also usable in PhoneGap applications since PhoneGap uses the underlying HTML geolocation APIs already. I have tested this on desktop Chrome, Safari, Firefox and on iOS and Android devices. I have not tested on IE9+ or Opera or Windows devices.
-<h3>Background:</h3>
-<a href="http://dev.w3.org/geo/api/spec-source.html" target="_blank">navigator.geolocation</a> provides the method <strong>geolocation.getCurrentPosition()</strong> that will return the current location of the device.  This seems easy enough so most developers simply call this method when they need the location. One of the options for this method is "enableHighAccuracy", which obviously implies that you need an accurate location. However, I soon discovered that if the device's GPS has not been used recently in the current location, it will take a while for it to acquire a decent location. The getCurrentPosition() success callback will trigger before the phone's GPS hardware can provide anything accurate. In other words, you get a quick response, but not necessarily an accurate response.
+# getAccurateCurrentPosition()
 
-In my own testing with an iPhone 4s and an HTC Inspire, when I would check getCurrentPosition() on the device, I would sometimes get an accuracy of over 1000 meters. Basically, the first location to be acquired is what is passed to the callback. What if you need more accuracy? You can re-call getCurrentPosition() and likely better accuracy because the GPS has had more time to acquire satellites, but how many times will you need to call it?
+A tiny, dependency-free enhancement to [`navigator.geolocation`](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API) that returns a **more accurate and predictable** location than a single `getCurrentPosition()` call.
 
-A better way to do this is to use <strong>navigator.geolocation.watchPosition()</strong>. This method will do a callback every time the location changes or every time the device improves the accuracy (based on my observations). In my own testing with a freshly booted device, it will take between 2 and 6 callbacks to get to something highly accurate.  This led me to write this very simple JavaScript function that uses watchPosition() in combination with a simple timer.
+It works in any geolocation-enabled web browser and in PhoneGap/Cordova apps (which use the same underlying HTML geolocation APIs). Tested on desktop Chrome, Safari, and Firefox, and on iOS and Android devices.
 
-The option parameters are identical to getCurrentPosition() with the following additions:
-<ul>
-   <li><strong>desiredAccuracy</strong>: The accuracy in meters that you consider "good enough". Once a location is found that meets this criterion, your callback will be called.</li>
-   <li><strong>maxWait</strong>: How long you are willing to wait (in milliseconds) for your desired accuracy. Once the function runs for maxWait milliseconds, it will stop trying and return the last location it was able to acquire. NOTE: If the desired accuracy is not achieved before the timeout, the onSuccess is still called. You will need to check the accuracy to confirm that you got what you expected. I did this because it's a "desired" accuracy, not a "required" accuracy. You can of course change this easily.</li>
-</ul>
-The following params also exist for getCurrentPosition() but are set for you in getAccurateCurrentPosition():
-<ul>
-   <li><strong>timeout</strong>: If no timeout is specified, it will be set to the maxWait value</li>
-   <li><strong>enableHighAccuracy</strong>: This is forced to true (otherwise, why are you using this function?!)</li>
-   <li><strong>maximumAge</strong>: This is forced to zero since we only want current location information</li>
-</ul>
+🔗 **[Live demo](https://gregsramblings.github.io/getAccurateCurrentPosition/)** · [Source on GitHub](https://github.com/gregsramblings/getAccurateCurrentPosition)
 
-<h3>Sample usage:</h3>
-<code>navigator.geolocation.getAccurateCurrentPosition(onSuccess, onError, onProgress, 
-                                                        {desiredAccuracy:20, maxWait:15000});</code>
+## The problem
 
-Translating the above options into english -- This will attempt to find the device location with an accuracy of at least 20 meters and attempt to achieve this accuracy for 15 seconds
+`navigator.geolocation.getCurrentPosition()` returns the *first* fix the device can produce. If the GPS hasn't been used recently in the current location, that first fix often comes from Wi-Fi or cell-tower triangulation and can be off by hundreds — sometimes thousands — of meters. You get a fast answer, but not necessarily an accurate one. Setting `enableHighAccuracy: true` doesn't fix this, because the callback still fires before the GPS hardware has had time to acquire satellites.
 
-Blogged at <a target="_blank" href="http://gregsramblings.com/2012/06/30/improving-geolocation-getcurrentposition-with-getaccuratecurrentposition/">http://gregsramblings.com/2012/06/30/improving-geolocation-getcurrentposition-with-getaccuratecurrentposition/</a>
+## The approach
+
+Instead of `getCurrentPosition()`, this library uses [`navigator.geolocation.watchPosition()`](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition), which fires repeatedly as the device refines its reading. On a freshly booted device it typically takes a handful of callbacks to converge on a good fix. `getAccurateCurrentPosition()` watches those updates and resolves as soon as a reading meets your desired accuracy — or returns the best reading it saw once a time limit is reached.
+
+## Usage
+
+Include the script — it attaches `getAccurateCurrentPosition` onto `navigator.geolocation`:
+
+```html
+<script src="geo.js"></script>
+```
+
+Then call it. The signature mirrors `getCurrentPosition()`, with an added progress callback:
+
+```js
+navigator.geolocation.getAccurateCurrentPosition(
+  onSuccess,
+  onError,
+  onProgress,
+  { desiredAccuracy: 20, maxWait: 15000 }
+);
+
+function onSuccess(position) {
+  // Fires when desiredAccuracy is met OR maxWait elapses (see note below).
+  console.log(position.coords.latitude, position.coords.longitude);
+  console.log('accuracy:', position.coords.accuracy, 'meters');
+}
+
+function onError(error) {
+  // Standard GeolocationPositionError (code 1/2/3) or, on timeout with no
+  // fix at all, { code: 3, message: ... }.
+  console.error(error.code, error.message);
+}
+
+function onProgress(position) {
+  // Optional. Called on each interim reading that didn't yet meet the target.
+  console.log('interim accuracy:', position.coords.accuracy, 'm');
+}
+```
+
+`onError` and `onProgress` are optional — pass `null` (or omit) if you don't need them.
+
+## Options
+
+These extend the standard `getCurrentPosition()` options:
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `desiredAccuracy` | `20` | The accuracy in meters you consider "good enough". The first reading at or below this resolves `onSuccess`. |
+| `maxWait` | `10000` | How long to keep trying, in milliseconds, before giving up and returning the best reading so far. |
+
+The following standard options are **set for you** and cannot be overridden:
+
+| Option | Forced value | Why |
+| --- | --- | --- |
+| `timeout` | `maxWait` | Aligns the watch timeout with how long you're willing to wait. |
+| `enableHighAccuracy` | `true` | The whole point of this function. |
+| `maximumAge` | `0` | We only want fresh readings, never a cached position. |
+
+> **Note:** `desiredAccuracy` is *desired*, not *required*. If `maxWait` elapses before it's met, `onSuccess` still fires with the most accurate reading collected — so check `position.coords.accuracy` if your use case truly requires the threshold. `onError` only fires on an actual geolocation error, or if `maxWait` elapses without **any** reading at all (code `3`, timeout).
+
+## Behavior details
+
+- **The first reading is ignored for the accuracy check** (unless it's the only one received). Some devices emit a cached position on the first event even with `maximumAge: 0`, so this avoids returning stale data. That first reading is still reported via `onProgress`.
+- **Callbacks fire at most once.** Late `watchPosition` events arriving after success or timeout are ignored, so `onSuccess`/`onError` never double-fire.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| [`geo.js`](geo.js) | The library — the only file you need. |
+| [`demo.html`](demo.html) | Live demo against your device's real GPS. |
+| [`test.html`](test.html) | 10 automated tests (mocked geolocation); open in any browser. |
+| [`index.html`](index.html) | Landing page linking the demo and tests. |
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
Modernizes the README from HTML-in-Markdown to clean Markdown and aligns it with the current `geo.js`.

## What changed
- Real 4-arg signature: `getAccurateCurrentPosition(onSuccess, onError, onProgress, options)`
- Options table with defaults (`desiredAccuracy` 20, `maxWait` 10000) and the forced values (`timeout`, `enableHighAccuracy`, `maximumAge`)
- Behavior notes: first-reading skip (cache-buster) and the fire-once guarantee
- Links to the demo, test, and landing pages
- Fixed the stale `gwilson` GitHub link → `gregsramblings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)